### PR TITLE
Feat: Core data CRUD 구현 완료

### DIFF
--- a/SueobHaro/ClassInfo+CoreDataClass.swift
+++ b/SueobHaro/ClassInfo+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ClassInfo+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class ClassInfo: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro.xcodeproj/project.pbxproj
+++ b/SueobHaro/SueobHaro.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		37B0421E288277E00043E9CB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0421D288277E00043E9CB /* ViewController.swift */; };
 		37B04223288277E20043E9CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37B04222288277E20043E9CB /* Assets.xcassets */; };
 		37B04226288277E20043E9CB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37B04224288277E20043E9CB /* LaunchScreen.storyboard */; };
+		37B04252288434D50043E9CB /* SueobHaro.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 37B04250288434D50043E9CB /* SueobHaro.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		37B04222288277E20043E9CB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		37B04225288277E20043E9CB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		37B04227288277E20043E9CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		37B04251288434D50043E9CB /* SueobHaro.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SueobHaro.xcdatamodel; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +62,7 @@
 				37B04222288277E20043E9CB /* Assets.xcassets */,
 				37B04224288277E20043E9CB /* LaunchScreen.storyboard */,
 				37B04227288277E20043E9CB /* Info.plist */,
+				37B04250288434D50043E9CB /* SueobHaro.xcdatamodeld */,
 			);
 			path = SueobHaro;
 			sourceTree = "<group>";
@@ -136,6 +139,7 @@
 			files = (
 				37B0421E288277E00043E9CB /* ViewController.swift in Sources */,
 				37B0421A288277E00043E9CB /* AppDelegate.swift in Sources */,
+				37B04252288434D50043E9CB /* SueobHaro.xcdatamodeld in Sources */,
 				37B0421C288277E00043E9CB /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -344,6 +348,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		37B04250288434D50043E9CB /* SueobHaro.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				37B04251288434D50043E9CB /* SueobHaro.xcdatamodel */,
+			);
+			currentVersion = 37B04251288434D50043E9CB /* SueobHaro.xcdatamodel */;
+			path = SueobHaro.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 37B0420E288277E00043E9CB /* Project object */;
 }

--- a/SueobHaro/SueobHaro.xcodeproj/project.pbxproj
+++ b/SueobHaro/SueobHaro.xcodeproj/project.pbxproj
@@ -14,14 +14,14 @@
 		37B04226288277E20043E9CB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37B04224288277E20043E9CB /* LaunchScreen.storyboard */; };
 		37B04252288434D50043E9CB /* SueobHaro.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 37B04250288434D50043E9CB /* SueobHaro.xcdatamodeld */; };
 		37B0427628848FC00043E9CB /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0427528848FC00043E9CB /* DataManager.swift */; };
-		37B0429F288493150043E9CB /* ClassInfo+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04297288493150043E9CB /* ClassInfo+CoreDataClass.swift */; };
-		37B042A0288493150043E9CB /* ClassInfo+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04298288493150043E9CB /* ClassInfo+CoreDataProperties.swift */; };
-		37B042A1288493150043E9CB /* Schedule+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04299288493150043E9CB /* Schedule+CoreDataClass.swift */; };
-		37B042A2288493150043E9CB /* Schedule+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429A288493150043E9CB /* Schedule+CoreDataProperties.swift */; };
-		37B042A3288493150043E9CB /* Members+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429B288493150043E9CB /* Members+CoreDataClass.swift */; };
-		37B042A4288493150043E9CB /* Members+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429C288493150043E9CB /* Members+CoreDataProperties.swift */; };
-		37B042A5288493150043E9CB /* ClassIteration+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429D288493150043E9CB /* ClassIteration+CoreDataClass.swift */; };
-		37B042A6288493150043E9CB /* ClassIteration+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429E288493150043E9CB /* ClassIteration+CoreDataProperties.swift */; };
+		37B042B428854A290043E9CB /* Schedule+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042AC28854A290043E9CB /* Schedule+CoreDataClass.swift */; };
+		37B042B528854A290043E9CB /* Schedule+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042AD28854A290043E9CB /* Schedule+CoreDataProperties.swift */; };
+		37B042B628854A290043E9CB /* Members+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042AE28854A290043E9CB /* Members+CoreDataClass.swift */; };
+		37B042B728854A290043E9CB /* Members+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042AF28854A290043E9CB /* Members+CoreDataProperties.swift */; };
+		37B042B828854A290043E9CB /* ClassIteration+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042B028854A290043E9CB /* ClassIteration+CoreDataClass.swift */; };
+		37B042B928854A290043E9CB /* ClassIteration+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042B128854A290043E9CB /* ClassIteration+CoreDataProperties.swift */; };
+		37B042CC28854F010043E9CB /* ClassInfo+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042CA28854F010043E9CB /* ClassInfo+CoreDataClass.swift */; };
+		37B042CD28854F010043E9CB /* ClassInfo+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B042CB28854F010043E9CB /* ClassInfo+CoreDataProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,14 +34,14 @@
 		37B04227288277E20043E9CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		37B04251288434D50043E9CB /* SueobHaro.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SueobHaro.xcdatamodel; sourceTree = "<group>"; };
 		37B0427528848FC00043E9CB /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
-		37B04297288493150043E9CB /* ClassInfo+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassInfo+CoreDataClass.swift"; sourceTree = "<group>"; };
-		37B04298288493150043E9CB /* ClassInfo+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassInfo+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		37B04299288493150043E9CB /* Schedule+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Schedule+CoreDataClass.swift"; sourceTree = "<group>"; };
-		37B0429A288493150043E9CB /* Schedule+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Schedule+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		37B0429B288493150043E9CB /* Members+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Members+CoreDataClass.swift"; sourceTree = "<group>"; };
-		37B0429C288493150043E9CB /* Members+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Members+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		37B0429D288493150043E9CB /* ClassIteration+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassIteration+CoreDataClass.swift"; sourceTree = "<group>"; };
-		37B0429E288493150043E9CB /* ClassIteration+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassIteration+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		37B042AC28854A290043E9CB /* Schedule+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Schedule+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B042AD28854A290043E9CB /* Schedule+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Schedule+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		37B042AE28854A290043E9CB /* Members+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Members+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B042AF28854A290043E9CB /* Members+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Members+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		37B042B028854A290043E9CB /* ClassIteration+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassIteration+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B042B128854A290043E9CB /* ClassIteration+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassIteration+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		37B042CA28854F010043E9CB /* ClassInfo+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ClassInfo+CoreDataClass.swift"; path = "../../../ClassInfo+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B042CB28854F010043E9CB /* ClassInfo+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ClassInfo+CoreDataProperties.swift"; path = "../../../ClassInfo+CoreDataProperties.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,10 +89,10 @@
 		37B0427328848DA00043E9CB /* DataModels */ = {
 			isa = PBXGroup;
 			children = (
-				37B042A8288493390043E9CB /* ClassInfo */,
-				37B042A9288493420043E9CB /* Schedule */,
-				37B042AA288493490043E9CB /* Members */,
-				37B042AB2884934F0043E9CB /* ClassIteration */,
+				37B042BC28854A350043E9CB /* Schedule */,
+				37B042BD28854A3C0043E9CB /* Members */,
+				37B042BE28854A480043E9CB /* ClassIteration */,
+				37B042BF28854A570043E9CB /* ClassInfo */,
 			);
 			path = DataModels;
 			sourceTree = "<group>";
@@ -106,40 +106,40 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
-		37B042A8288493390043E9CB /* ClassInfo */ = {
+		37B042BC28854A350043E9CB /* Schedule */ = {
 			isa = PBXGroup;
 			children = (
-				37B04297288493150043E9CB /* ClassInfo+CoreDataClass.swift */,
-				37B04298288493150043E9CB /* ClassInfo+CoreDataProperties.swift */,
-			);
-			path = ClassInfo;
-			sourceTree = "<group>";
-		};
-		37B042A9288493420043E9CB /* Schedule */ = {
-			isa = PBXGroup;
-			children = (
-				37B04299288493150043E9CB /* Schedule+CoreDataClass.swift */,
-				37B0429A288493150043E9CB /* Schedule+CoreDataProperties.swift */,
+				37B042AC28854A290043E9CB /* Schedule+CoreDataClass.swift */,
+				37B042AD28854A290043E9CB /* Schedule+CoreDataProperties.swift */,
 			);
 			path = Schedule;
 			sourceTree = "<group>";
 		};
-		37B042AA288493490043E9CB /* Members */ = {
+		37B042BD28854A3C0043E9CB /* Members */ = {
 			isa = PBXGroup;
 			children = (
-				37B0429B288493150043E9CB /* Members+CoreDataClass.swift */,
-				37B0429C288493150043E9CB /* Members+CoreDataProperties.swift */,
+				37B042AE28854A290043E9CB /* Members+CoreDataClass.swift */,
+				37B042AF28854A290043E9CB /* Members+CoreDataProperties.swift */,
 			);
 			path = Members;
 			sourceTree = "<group>";
 		};
-		37B042AB2884934F0043E9CB /* ClassIteration */ = {
+		37B042BE28854A480043E9CB /* ClassIteration */ = {
 			isa = PBXGroup;
 			children = (
-				37B0429D288493150043E9CB /* ClassIteration+CoreDataClass.swift */,
-				37B0429E288493150043E9CB /* ClassIteration+CoreDataProperties.swift */,
+				37B042B028854A290043E9CB /* ClassIteration+CoreDataClass.swift */,
+				37B042B128854A290043E9CB /* ClassIteration+CoreDataProperties.swift */,
 			);
 			path = ClassIteration;
+			sourceTree = "<group>";
+		};
+		37B042BF28854A570043E9CB /* ClassInfo */ = {
+			isa = PBXGroup;
+			children = (
+				37B042CA28854F010043E9CB /* ClassInfo+CoreDataClass.swift */,
+				37B042CB28854F010043E9CB /* ClassInfo+CoreDataProperties.swift */,
+			);
+			path = ClassInfo;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -212,19 +212,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				37B042A1288493150043E9CB /* Schedule+CoreDataClass.swift in Sources */,
 				37B0421E288277E00043E9CB /* ViewController.swift in Sources */,
-				37B042A5288493150043E9CB /* ClassIteration+CoreDataClass.swift in Sources */,
 				37B0427628848FC00043E9CB /* DataManager.swift in Sources */,
-				37B042A2288493150043E9CB /* Schedule+CoreDataProperties.swift in Sources */,
+				37B042B728854A290043E9CB /* Members+CoreDataProperties.swift in Sources */,
 				37B0421A288277E00043E9CB /* AppDelegate.swift in Sources */,
-				37B042A6288493150043E9CB /* ClassIteration+CoreDataProperties.swift in Sources */,
-				37B042A4288493150043E9CB /* Members+CoreDataProperties.swift in Sources */,
 				37B04252288434D50043E9CB /* SueobHaro.xcdatamodeld in Sources */,
-				37B0429F288493150043E9CB /* ClassInfo+CoreDataClass.swift in Sources */,
-				37B042A3288493150043E9CB /* Members+CoreDataClass.swift in Sources */,
-				37B042A0288493150043E9CB /* ClassInfo+CoreDataProperties.swift in Sources */,
+				37B042B928854A290043E9CB /* ClassIteration+CoreDataProperties.swift in Sources */,
+				37B042CD28854F010043E9CB /* ClassInfo+CoreDataProperties.swift in Sources */,
+				37B042B428854A290043E9CB /* Schedule+CoreDataClass.swift in Sources */,
+				37B042B628854A290043E9CB /* Members+CoreDataClass.swift in Sources */,
 				37B0421C288277E00043E9CB /* SceneDelegate.swift in Sources */,
+				37B042B828854A290043E9CB /* ClassIteration+CoreDataClass.swift in Sources */,
+				37B042CC28854F010043E9CB /* ClassInfo+CoreDataClass.swift in Sources */,
+				37B042B528854A290043E9CB /* Schedule+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SueobHaro/SueobHaro.xcodeproj/project.pbxproj
+++ b/SueobHaro/SueobHaro.xcodeproj/project.pbxproj
@@ -13,6 +13,15 @@
 		37B04223288277E20043E9CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 37B04222288277E20043E9CB /* Assets.xcassets */; };
 		37B04226288277E20043E9CB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 37B04224288277E20043E9CB /* LaunchScreen.storyboard */; };
 		37B04252288434D50043E9CB /* SueobHaro.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 37B04250288434D50043E9CB /* SueobHaro.xcdatamodeld */; };
+		37B0427628848FC00043E9CB /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0427528848FC00043E9CB /* DataManager.swift */; };
+		37B0429F288493150043E9CB /* ClassInfo+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04297288493150043E9CB /* ClassInfo+CoreDataClass.swift */; };
+		37B042A0288493150043E9CB /* ClassInfo+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04298288493150043E9CB /* ClassInfo+CoreDataProperties.swift */; };
+		37B042A1288493150043E9CB /* Schedule+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B04299288493150043E9CB /* Schedule+CoreDataClass.swift */; };
+		37B042A2288493150043E9CB /* Schedule+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429A288493150043E9CB /* Schedule+CoreDataProperties.swift */; };
+		37B042A3288493150043E9CB /* Members+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429B288493150043E9CB /* Members+CoreDataClass.swift */; };
+		37B042A4288493150043E9CB /* Members+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429C288493150043E9CB /* Members+CoreDataProperties.swift */; };
+		37B042A5288493150043E9CB /* ClassIteration+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429D288493150043E9CB /* ClassIteration+CoreDataClass.swift */; };
+		37B042A6288493150043E9CB /* ClassIteration+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0429E288493150043E9CB /* ClassIteration+CoreDataProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +33,15 @@
 		37B04225288277E20043E9CB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		37B04227288277E20043E9CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		37B04251288434D50043E9CB /* SueobHaro.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = SueobHaro.xcdatamodel; sourceTree = "<group>"; };
+		37B0427528848FC00043E9CB /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
+		37B04297288493150043E9CB /* ClassInfo+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassInfo+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B04298288493150043E9CB /* ClassInfo+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassInfo+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		37B04299288493150043E9CB /* Schedule+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Schedule+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B0429A288493150043E9CB /* Schedule+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Schedule+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		37B0429B288493150043E9CB /* Members+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Members+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B0429C288493150043E9CB /* Members+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Members+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		37B0429D288493150043E9CB /* ClassIteration+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassIteration+CoreDataClass.swift"; sourceTree = "<group>"; };
+		37B0429E288493150043E9CB /* ClassIteration+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClassIteration+CoreDataProperties.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +74,7 @@
 		37B04218288277E00043E9CB /* SueobHaro */ = {
 			isa = PBXGroup;
 			children = (
+				37B0427428848F8B0043E9CB /* Model */,
 				37B04219288277E00043E9CB /* AppDelegate.swift */,
 				37B0421B288277E00043E9CB /* SceneDelegate.swift */,
 				37B0421D288277E00043E9CB /* ViewController.swift */,
@@ -65,6 +84,62 @@
 				37B04250288434D50043E9CB /* SueobHaro.xcdatamodeld */,
 			);
 			path = SueobHaro;
+			sourceTree = "<group>";
+		};
+		37B0427328848DA00043E9CB /* DataModels */ = {
+			isa = PBXGroup;
+			children = (
+				37B042A8288493390043E9CB /* ClassInfo */,
+				37B042A9288493420043E9CB /* Schedule */,
+				37B042AA288493490043E9CB /* Members */,
+				37B042AB2884934F0043E9CB /* ClassIteration */,
+			);
+			path = DataModels;
+			sourceTree = "<group>";
+		};
+		37B0427428848F8B0043E9CB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				37B0427328848DA00043E9CB /* DataModels */,
+				37B0427528848FC00043E9CB /* DataManager.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		37B042A8288493390043E9CB /* ClassInfo */ = {
+			isa = PBXGroup;
+			children = (
+				37B04297288493150043E9CB /* ClassInfo+CoreDataClass.swift */,
+				37B04298288493150043E9CB /* ClassInfo+CoreDataProperties.swift */,
+			);
+			path = ClassInfo;
+			sourceTree = "<group>";
+		};
+		37B042A9288493420043E9CB /* Schedule */ = {
+			isa = PBXGroup;
+			children = (
+				37B04299288493150043E9CB /* Schedule+CoreDataClass.swift */,
+				37B0429A288493150043E9CB /* Schedule+CoreDataProperties.swift */,
+			);
+			path = Schedule;
+			sourceTree = "<group>";
+		};
+		37B042AA288493490043E9CB /* Members */ = {
+			isa = PBXGroup;
+			children = (
+				37B0429B288493150043E9CB /* Members+CoreDataClass.swift */,
+				37B0429C288493150043E9CB /* Members+CoreDataProperties.swift */,
+			);
+			path = Members;
+			sourceTree = "<group>";
+		};
+		37B042AB2884934F0043E9CB /* ClassIteration */ = {
+			isa = PBXGroup;
+			children = (
+				37B0429D288493150043E9CB /* ClassIteration+CoreDataClass.swift */,
+				37B0429E288493150043E9CB /* ClassIteration+CoreDataProperties.swift */,
+			);
+			path = ClassIteration;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,9 +212,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				37B042A1288493150043E9CB /* Schedule+CoreDataClass.swift in Sources */,
 				37B0421E288277E00043E9CB /* ViewController.swift in Sources */,
+				37B042A5288493150043E9CB /* ClassIteration+CoreDataClass.swift in Sources */,
+				37B0427628848FC00043E9CB /* DataManager.swift in Sources */,
+				37B042A2288493150043E9CB /* Schedule+CoreDataProperties.swift in Sources */,
 				37B0421A288277E00043E9CB /* AppDelegate.swift in Sources */,
+				37B042A6288493150043E9CB /* ClassIteration+CoreDataProperties.swift in Sources */,
+				37B042A4288493150043E9CB /* Members+CoreDataProperties.swift in Sources */,
 				37B04252288434D50043E9CB /* SueobHaro.xcdatamodeld in Sources */,
+				37B0429F288493150043E9CB /* ClassInfo+CoreDataClass.swift in Sources */,
+				37B042A3288493150043E9CB /* Members+CoreDataClass.swift in Sources */,
+				37B042A0288493150043E9CB /* ClassInfo+CoreDataProperties.swift in Sources */,
 				37B0421C288277E00043E9CB /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SueobHaro/SueobHaro/AppDelegate.swift
+++ b/SueobHaro/SueobHaro/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -31,6 +32,49 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
+    // MARK: - Core Data stack
 
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+        */
+        let container = NSPersistentContainer(name: "SueobHaro")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                 
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
 }
 

--- a/SueobHaro/SueobHaro/AppDelegate.swift
+++ b/SueobHaro/SueobHaro/AppDelegate.swift
@@ -6,75 +6,29 @@
 //
 
 import UIKit
-import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
+    
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-    // MARK: - Core Data stack
-
-    lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-        */
-        let container = NSPersistentContainer(name: "SueobHaro")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
+    
+    
 }
 

--- a/SueobHaro/SueobHaro/ClassInfo+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/ClassInfo+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ClassInfo+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class ClassInfo: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/ClassInfo+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/ClassInfo+CoreDataProperties.swift
@@ -23,26 +23,26 @@ extension ClassInfo {
     @NSManaged public var name: String?
     @NSManaged public var color: String?
     @NSManaged public var location: String?
-    @NSManaged public var schdule: NSSet?
+    @NSManaged public var schedule: NSSet?
     @NSManaged public var classIteration: NSSet?
     @NSManaged public var members: NSSet?
 
 }
 
-// MARK: Generated accessors for schdule
+// MARK: Generated accessors for schedule
 extension ClassInfo {
 
-    @objc(addSchduleObject:)
-    @NSManaged public func addToSchdule(_ value: Schedule)
+    @objc(addScheduleObject:)
+    @NSManaged public func addToSchedule(_ value: Schedule)
 
-    @objc(removeSchduleObject:)
-    @NSManaged public func removeFromSchdule(_ value: Schedule)
+    @objc(removeScheduleObject:)
+    @NSManaged public func removeFromSchedule(_ value: Schedule)
 
-    @objc(addSchdule:)
-    @NSManaged public func addToSchdule(_ values: NSSet)
+    @objc(addSchedule:)
+    @NSManaged public func addToSchedule(_ values: NSSet)
 
-    @objc(removeSchdule:)
-    @NSManaged public func removeFromSchdule(_ values: NSSet)
+    @objc(removeSchedule:)
+    @NSManaged public func removeFromSchedule(_ values: NSSet)
 
 }
 

--- a/SueobHaro/SueobHaro/Model/DataManager.swift
+++ b/SueobHaro/SueobHaro/Model/DataManager.swift
@@ -1,0 +1,131 @@
+//
+//  DataManager.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+
+import Foundation
+import CoreData
+
+
+class DataManager {
+    // MARK: Singleton
+    static let shared = DataManager()
+    private init() {}
+    
+    
+    // MARK: CoreData Container
+    var container: NSPersistentContainer!
+    
+    
+    // MARK: Data
+    var classInfo: [ClassInfo]?
+    var schedule: [Schedule]?
+    var members: [Members]?
+    var classIteration: [ClassIteration]?
+    
+    
+    // MARK: Create
+    func addClassInfo(id: String, firstDate: Date, tuition: Int32, tuitionPer: Int16) -> Void {
+        let newClassInfo = ClassInfo(context: container.viewContext)
+        newClassInfo.id = id
+        newClassInfo.firstDate = firstDate
+        newClassInfo.tuition = tuition
+        newClassInfo.tuitionPer = tuitionPer
+        try? container.viewContext.save()
+    }
+    
+    func addSchedule(id: String, count: Int16, endTime: Date, startTime: Date, isCanceled: Bool, progress: String) -> Void {
+        let newSchedule = Schedule(context: container.viewContext)
+        newSchedule.id = id
+        newSchedule.count = count
+        newSchedule.endTime = endTime
+        newSchedule.startTime = startTime
+        newSchedule.isCanceled = isCanceled
+        newSchedule.progress = progress
+        try? container.viewContext.save()
+    }
+    
+    func addMember(id: String, name: String, phoneNumber: String) -> Void {
+        let newMember = Members(context: container.viewContext)
+        newMember.id = id
+        newMember.name = name
+        newMember.phoneNumber = phoneNumber
+        try? container.viewContext.save()
+    }
+    
+    func addClassIteration(id: String, day: String, startTime: Date, endTime: Date) -> Void {
+        let newClassIteration = ClassIteration(context: container.viewContext)
+        newClassIteration.id = id
+        newClassIteration.day = day
+        newClassIteration.startTime = startTime
+        newClassIteration.endTime = endTime
+        try? container.viewContext.save()
+    }
+    
+    
+    // MARK: Read
+    func fetchData(target: DataModel) -> Void {
+        switch target {
+        case .classInfo:
+            classInfo = try? container.viewContext.fetch(ClassInfo.fetchRequest())
+        case .schedule:
+            schedule = try? container.viewContext.fetch(Schedule.fetchRequest())
+        case .members:
+            members = try? container.viewContext.fetch(Members.fetchRequest())
+        case .classIteration:
+            classIteration = try? container.viewContext.fetch(ClassIteration.fetchRequest())
+        }
+    }
+    
+    
+    // MARK: Update (업데이트 필요한 내용만 값을 넘기고, 업데이트 하지 않는 프로퍼티는 nil을 넘겨주시면 됩니다.)
+    func updateClassInfo(target: ClassInfo, id: String?, firstDate: Date?, tuition: Int32?, tuitionPer: Int16?) -> Void {
+        if let id = id { target.id = id }
+        if let firstDate = firstDate { target.firstDate = firstDate }
+        if let tuition = tuition { target.tuition = tuition }
+        if let tuitionPer = tuitionPer { target.tuitionPer = tuitionPer }
+        try? container.viewContext.save()
+    }
+    
+    func updateSchedule(target: Schedule, id: String?, count: Int16?, endTime: Date?, startTime: Date?, isCanceled: Bool?, progress: String?) -> Void {
+        if let id = id { target.id = id }
+        if let count = count { target.count = count }
+        if let endTime = endTime { target.endTime = endTime }
+        if let startTime = startTime { target.startTime = startTime }
+        if let isCanceled = isCanceled { target.isCanceled = isCanceled }
+        if let progress = progress { target.progress = progress }
+        try? container.viewContext.save()
+    }
+    
+    func updateMember(target: Members, id: String?, name: String?, phoneNumber: String?) -> Void {
+        if let id = id { target.id = id }
+        if let name = name { target.name = name }
+        if let phoneNumber = phoneNumber { target.phoneNumber = phoneNumber }
+        try? container.viewContext.save()
+    }
+    
+    func updateClassIteration(target: ClassIteration, id: String?, day: String?, startTime: Date?, endTime: Date?) -> Void {
+        if let id = id { target.id = id }
+        if let day = day { target.day = day }
+        if let startTime = startTime { target.startTime = startTime }
+        if let endTime = endTime { target.endTime = endTime }
+        try? container.viewContext.save()
+    }
+    
+    
+    // MARK: Delete
+    func deleteData<T>(target: T) -> Void {
+        container.viewContext.delete(target as! NSManagedObject)
+        try? container.viewContext.save()
+    }
+}
+
+// MARK: DataModel
+enum DataModel {
+    case classInfo
+    case schedule
+    case members
+    case classIteration
+}

--- a/SueobHaro/SueobHaro/Model/DataManager.swift
+++ b/SueobHaro/SueobHaro/Model/DataManager.swift
@@ -27,40 +27,55 @@ class DataManager {
     
     
     // MARK: Create
-    func addClassInfo(id: String, firstDate: Date, tuition: Int32, tuitionPer: Int16) -> Void {
+    func addClassInfo(firstDate: Date, tuition: Int32, tuitionPer: Int16, name: String, color: String, location: String, day: [String], startTime: [Date], endTime: [Date], memberName: [String], memberPhoneNumber: [String]) -> Void {
         let newClassInfo = ClassInfo(context: container.viewContext)
-        newClassInfo.id = id
+        newClassInfo.id = UUID()
         newClassInfo.firstDate = firstDate
         newClassInfo.tuition = tuition
         newClassInfo.tuitionPer = tuitionPer
+        newClassInfo.name = name
+        newClassInfo.color = color
+        newClassInfo.location = location
         try? container.viewContext.save()
+        
+        guard max(day.count, startTime.count, endTime.count) == min(day.count, startTime.count, endTime.count) else { fatalError("반복 정보 갯수 불일치") }
+        for idx in 0..<day.count {
+            addClassIteration(day: day[idx], startTime: startTime[idx], endTime: endTime[idx], classInfo: newClassInfo)
+        }
+        guard max(memberName.count, memberPhoneNumber.count) == min(memberName.count, memberPhoneNumber.count) else { fatalError("맴버 정보 갯수 불일치") }
+        for idx in 0..<memberName.count {
+            addMember(name: memberName[idx], phoneNumber: memberPhoneNumber[idx], classInfo: newClassInfo)
+        }
     }
     
-    func addSchedule(id: String, count: Int16, endTime: Date, startTime: Date, isCanceled: Bool, progress: String) -> Void {
+    func addSchedule(count: Int16, endTime: Date, startTime: Date, isCanceled: Bool, progress: String, classInfo: ClassInfo) -> Void {
         let newSchedule = Schedule(context: container.viewContext)
-        newSchedule.id = id
+        newSchedule.id = UUID()
         newSchedule.count = count
         newSchedule.endTime = endTime
         newSchedule.startTime = startTime
         newSchedule.isCanceled = isCanceled
         newSchedule.progress = progress
+        newSchedule.classInfo = classInfo
         try? container.viewContext.save()
     }
     
-    func addMember(id: String, name: String, phoneNumber: String) -> Void {
+    func addMember(name: String, phoneNumber: String, classInfo: ClassInfo) -> Void {
         let newMember = Members(context: container.viewContext)
-        newMember.id = id
+        newMember.id = UUID()
         newMember.name = name
         newMember.phoneNumber = phoneNumber
+        newMember.classInfo = classInfo
         try? container.viewContext.save()
     }
     
-    func addClassIteration(id: String, day: String, startTime: Date, endTime: Date) -> Void {
+    func addClassIteration(day: String, startTime: Date, endTime: Date, classInfo: ClassInfo) -> Void {
         let newClassIteration = ClassIteration(context: container.viewContext)
-        newClassIteration.id = id
+        newClassIteration.id = UUID()
         newClassIteration.day = day
         newClassIteration.startTime = startTime
         newClassIteration.endTime = endTime
+        newClassIteration.classInfo = classInfo
         try? container.viewContext.save()
     }
     
@@ -81,16 +96,17 @@ class DataManager {
     
     
     // MARK: Update (업데이트 필요한 내용만 값을 넘기고, 업데이트 하지 않는 프로퍼티는 nil을 넘겨주시면 됩니다.)
-    func updateClassInfo(target: ClassInfo, id: String?, firstDate: Date?, tuition: Int32?, tuitionPer: Int16?) -> Void {
-        if let id = id { target.id = id }
+    func updateClassInfo(target: ClassInfo, firstDate: Date?, tuition: Int32?, tuitionPer: Int16?, name: String?, color: String?, location: String?) -> Void {
         if let firstDate = firstDate { target.firstDate = firstDate }
         if let tuition = tuition { target.tuition = tuition }
         if let tuitionPer = tuitionPer { target.tuitionPer = tuitionPer }
+        if let name = name { target.name = name }
+        if let color = color { target.color = color }
+        if let location = location { target.location = location }
         try? container.viewContext.save()
     }
     
-    func updateSchedule(target: Schedule, id: String?, count: Int16?, endTime: Date?, startTime: Date?, isCanceled: Bool?, progress: String?) -> Void {
-        if let id = id { target.id = id }
+    func updateSchedule(target: Schedule, count: Int16?, endTime: Date?, startTime: Date?, isCanceled: Bool?, progress: String?) -> Void {
         if let count = count { target.count = count }
         if let endTime = endTime { target.endTime = endTime }
         if let startTime = startTime { target.startTime = startTime }
@@ -99,15 +115,13 @@ class DataManager {
         try? container.viewContext.save()
     }
     
-    func updateMember(target: Members, id: String?, name: String?, phoneNumber: String?) -> Void {
-        if let id = id { target.id = id }
+    func updateMember(target: Members, name: String?, phoneNumber: String?) -> Void {
         if let name = name { target.name = name }
         if let phoneNumber = phoneNumber { target.phoneNumber = phoneNumber }
         try? container.viewContext.save()
     }
     
-    func updateClassIteration(target: ClassIteration, id: String?, day: String?, startTime: Date?, endTime: Date?) -> Void {
-        if let id = id { target.id = id }
+    func updateClassIteration(target: ClassIteration, day: String?, startTime: Date?, endTime: Date?) -> Void {
         if let day = day { target.day = day }
         if let startTime = startTime { target.startTime = startTime }
         if let endTime = endTime { target.endTime = endTime }

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassInfo+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassInfo+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ClassInfo+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ClassInfo)
+public class ClassInfo: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassInfo+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassInfo+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  ClassInfo+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ClassInfo {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ClassInfo> {
+        return NSFetchRequest<ClassInfo>(entityName: "ClassInfo")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var firstDate: Date?
+    @NSManaged public var tuition: Int32
+    @NSManaged public var tuitionPer: Int16
+
+}
+
+extension ClassInfo : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassInfo/ClassInfo+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassInfo/ClassInfo+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ClassInfo+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class ClassInfo: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassInfo/ClassInfo+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassInfo/ClassInfo+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  ClassInfo+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ClassInfo {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ClassInfo> {
+        return NSFetchRequest<ClassInfo>(entityName: "ClassInfo")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var firstDate: Date?
+    @NSManaged public var tuition: Int32
+    @NSManaged public var tuitionPer: Int16
+
+}
+
+extension ClassInfo : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassIteration+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassIteration+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ClassIteration+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(ClassIteration)
+public class ClassIteration: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassIteration+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassIteration+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  ClassIteration+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ClassIteration {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ClassIteration> {
+        return NSFetchRequest<ClassIteration>(entityName: "ClassIteration")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var day: String?
+    @NSManaged public var startTime: Date?
+    @NSManaged public var endTime: Date?
+
+}
+
+extension ClassIteration : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassIteration/ClassIteration+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassIteration/ClassIteration+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  ClassIteration+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class ClassIteration: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassIteration/ClassIteration+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassIteration/ClassIteration+CoreDataProperties.swift
@@ -16,10 +16,11 @@ extension ClassIteration {
         return NSFetchRequest<ClassIteration>(entityName: "ClassIteration")
     }
 
-    @NSManaged public var id: String?
+    @NSManaged public var id: UUID?
     @NSManaged public var day: String?
     @NSManaged public var startTime: Date?
     @NSManaged public var endTime: Date?
+    @NSManaged public var classInfo: ClassInfo?
 
 }
 

--- a/SueobHaro/SueobHaro/Model/DataModels/ClassIteration/ClassIteration+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/ClassIteration/ClassIteration+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  ClassIteration+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension ClassIteration {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ClassIteration> {
+        return NSFetchRequest<ClassIteration>(entityName: "ClassIteration")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var day: String?
+    @NSManaged public var startTime: Date?
+    @NSManaged public var endTime: Date?
+
+}
+
+extension ClassIteration : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Members+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Members+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Members+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Members)
+public class Members: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Members+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Members+CoreDataProperties.swift
@@ -1,0 +1,27 @@
+//
+//  Members+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Members {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Members> {
+        return NSFetchRequest<Members>(entityName: "Members")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var name: String?
+    @NSManaged public var phoneNumber: String?
+
+}
+
+extension Members : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Members/Members+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Members/Members+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Members+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class Members: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Members/Members+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Members/Members+CoreDataProperties.swift
@@ -16,9 +16,10 @@ extension Members {
         return NSFetchRequest<Members>(entityName: "Members")
     }
 
-    @NSManaged public var id: String?
+    @NSManaged public var id: UUID?
     @NSManaged public var name: String?
     @NSManaged public var phoneNumber: String?
+    @NSManaged public var classInfo: ClassInfo?
 
 }
 

--- a/SueobHaro/SueobHaro/Model/DataModels/Members/Members+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Members/Members+CoreDataProperties.swift
@@ -1,0 +1,27 @@
+//
+//  Members+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Members {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Members> {
+        return NSFetchRequest<Members>(entityName: "Members")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var name: String?
+    @NSManaged public var phoneNumber: String?
+
+}
+
+extension Members : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Schedule+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Schedule+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Schedule+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Schedule)
+public class Schedule: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Schedule+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Schedule+CoreDataProperties.swift
@@ -1,0 +1,30 @@
+//
+//  Schedule+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Schedule {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Schedule> {
+        return NSFetchRequest<Schedule>(entityName: "Schedule")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var startTime: Date?
+    @NSManaged public var endTime: Date?
+    @NSManaged public var progress: String?
+    @NSManaged public var count: Int16
+    @NSManaged public var isCanceled: Bool
+
+}
+
+extension Schedule : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Schedule/Schedule+CoreDataClass.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Schedule/Schedule+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Schedule+CoreDataClass.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class Schedule: NSManagedObject {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Schedule/Schedule+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Schedule/Schedule+CoreDataProperties.swift
@@ -1,0 +1,30 @@
+//
+//  Schedule+CoreDataProperties.swift
+//  SueobHaro
+//
+//  Created by leejunmo on 2022/07/18.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Schedule {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Schedule> {
+        return NSFetchRequest<Schedule>(entityName: "Schedule")
+    }
+
+    @NSManaged public var id: String?
+    @NSManaged public var startTime: Date?
+    @NSManaged public var endTime: Date?
+    @NSManaged public var progress: String?
+    @NSManaged public var count: Int16
+    @NSManaged public var isCanceled: Bool
+
+}
+
+extension Schedule : Identifiable {
+
+}

--- a/SueobHaro/SueobHaro/Model/DataModels/Schedule/Schedule+CoreDataProperties.swift
+++ b/SueobHaro/SueobHaro/Model/DataModels/Schedule/Schedule+CoreDataProperties.swift
@@ -16,12 +16,13 @@ extension Schedule {
         return NSFetchRequest<Schedule>(entityName: "Schedule")
     }
 
-    @NSManaged public var id: String?
+    @NSManaged public var id: UUID?
     @NSManaged public var startTime: Date?
     @NSManaged public var endTime: Date?
     @NSManaged public var progress: String?
     @NSManaged public var count: Int16
     @NSManaged public var isCanceled: Bool
+    @NSManaged public var classInfo: ClassInfo?
 
 }
 

--- a/SueobHaro/SueobHaro/SceneDelegate.swift
+++ b/SueobHaro/SueobHaro/SceneDelegate.swift
@@ -18,9 +18,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
+        DataManager.shared.container = persistentContainer
         window = UIWindow(windowScene: windowScene)
         let viewController = ViewController()
-        viewController.container = persistentContainer
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
     }

--- a/SueobHaro/SueobHaro/SceneDelegate.swift
+++ b/SueobHaro/SueobHaro/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreData
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -19,6 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         let viewController = ViewController()
+        viewController.container = persistentContainer
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
     }
@@ -51,6 +53,50 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-
+    
+    // MARK: - Core Data stack
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+         */
+        let container = NSPersistentContainer(name: "SueobHaro")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    // MARK: - Core Data Saving support
+    
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
 }
 

--- a/SueobHaro/SueobHaro/SueobHaro.xcdatamodeld/SueobHaro.xcdatamodel/contents
+++ b/SueobHaro/SueobHaro/SueobHaro.xcdatamodeld/SueobHaro.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <elements/>
+</model>

--- a/SueobHaro/SueobHaro/SueobHaro.xcdatamodeld/SueobHaro.xcdatamodel/contents
+++ b/SueobHaro/SueobHaro/SueobHaro.xcdatamodeld/SueobHaro.xcdatamodel/contents
@@ -1,34 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ClassInfo" representedClassName=".ClassInfo" syncable="YES">
+        <attribute name="color" optional="YES" attributeType="String"/>
         <attribute name="firstDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="location" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="tuition" optional="YES" attributeType="Integer 32" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="tuitionPer" optional="YES" attributeType="Integer 16" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="classIteration" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ClassIteration" inverseName="classInfo" inverseEntity="ClassIteration"/>
+        <relationship name="members" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Members" inverseName="classInfo" inverseEntity="Members"/>
+        <relationship name="schedule" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Schedule" inverseName="classInfo" inverseEntity="Schedule"/>
     </entity>
     <entity name="ClassIteration" representedClassName=".ClassIteration" syncable="YES">
         <attribute name="day" optional="YES" attributeType="String"/>
         <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="classInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClassInfo" inverseName="classIteration" inverseEntity="ClassInfo"/>
     </entity>
     <entity name="Members" representedClassName=".Members" syncable="YES">
-        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="phoneNumber" optional="YES" attributeType="String"/>
+        <relationship name="classInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClassInfo" inverseName="members" inverseEntity="ClassInfo"/>
     </entity>
     <entity name="Schedule" representedClassName=".Schedule" syncable="YES">
         <attribute name="count" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isCanceled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="progress" optional="YES" attributeType="String"/>
         <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="classInfo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClassInfo" inverseName="schedule" inverseEntity="ClassInfo"/>
     </entity>
     <elements>
-        <element name="Schedule" positionX="-144.30078125" positionY="-35.125" width="128" height="133"/>
-        <element name="ClassInfo" positionX="-60.46484375" positionY="81.46875" width="128" height="103"/>
-        <element name="Members" positionX="51.53515625" positionY="209.75" width="128" height="88"/>
-        <element name="ClassIteration" positionX="182.1953125" positionY="113.76171875" width="128" height="43"/>
+        <element name="Schedule" positionX="241.82421875" positionY="-48.16796875" width="128" height="43"/>
+        <element name="ClassInfo" positionX="-186.1953125" positionY="-245.9453125" width="128" height="193"/>
+        <element name="Members" positionX="-450.91015625" positionY="-44.20703125" width="128" height="103"/>
+        <element name="ClassIteration" positionX="-228.25" positionY="178.42578125" width="128" height="118"/>
     </elements>
 </model>

--- a/SueobHaro/SueobHaro/SueobHaro.xcdatamodeld/SueobHaro.xcdatamodel/contents
+++ b/SueobHaro/SueobHaro/SueobHaro.xcdatamodeld/SueobHaro.xcdatamodel/contents
@@ -1,4 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <elements/>
+    <entity name="ClassInfo" representedClassName=".ClassInfo" syncable="YES">
+        <attribute name="firstDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="tuition" optional="YES" attributeType="Integer 32" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="tuitionPer" optional="YES" attributeType="Integer 16" defaultValueString="0.0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="ClassIteration" representedClassName=".ClassIteration" syncable="YES">
+        <attribute name="day" optional="YES" attributeType="String"/>
+        <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <entity name="Members" representedClassName=".Members" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Schedule" representedClassName=".Schedule" syncable="YES">
+        <attribute name="count" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="isCanceled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="progress" optional="YES" attributeType="String"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <elements>
+        <element name="Schedule" positionX="-144.30078125" positionY="-35.125" width="128" height="133"/>
+        <element name="ClassInfo" positionX="-60.46484375" positionY="81.46875" width="128" height="103"/>
+        <element name="Members" positionX="51.53515625" positionY="209.75" width="128" height="88"/>
+        <element name="ClassIteration" positionX="182.1953125" positionY="113.76171875" width="128" height="43"/>
+    </elements>
 </model>

--- a/SueobHaro/SueobHaro/ViewController.swift
+++ b/SueobHaro/SueobHaro/ViewController.swift
@@ -6,12 +6,17 @@
 //
 
 import UIKit
+import CoreData
 
 class ViewController: UIViewController {
+    
+    var container: NSPersistentContainer!
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        guard container != nil else { fatalError("This view needs a persistent container.") }
+        
+        
     }
 
 

--- a/SueobHaro/SueobHaro/ViewController.swift
+++ b/SueobHaro/SueobHaro/ViewController.swift
@@ -17,3 +17,5 @@ class ViewController: UIViewController {
     
 }
 
+
+

--- a/SueobHaro/SueobHaro/ViewController.swift
+++ b/SueobHaro/SueobHaro/ViewController.swift
@@ -10,15 +10,10 @@ import CoreData
 
 class ViewController: UIViewController {
     
-    var container: NSPersistentContainer!
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        guard container != nil else { fatalError("This view needs a persistent container.") }
-        
-        
+        guard DataManager.shared.container != nil else { fatalError("This view needs a persistent container.") }
     }
-
-
+    
 }
 


### PR DESCRIPTION
# 작업 사항
- CoreData 모델 생성
- CURD 기능 구현

# 설명 및 이유
- 여러뷰에서 동일한 데이터를 사용하기 위해 데이터 모델(DataManager)을 싱글톤으로  구현하였습니다.
- Create 와 Update는 수정 되는 attribute의 타입이 Entity마다 다르기에 함수를 Entity별로 따로 구현을 하였고, Read와 Delete는 하나의 함수로 구현하였습니다.
- persistentContainer연결은 SceneDelegate의 willConnectTo 부분에서 구현하였습니다.
- 데이터에 대한 접근은 DataManager의 Data로 마크된 프로퍼티들로 접근가능하며, 각각 해당 Entity의 배열(옵셔널)로 구성되어있습니다.

# PR 포인트

- [x] 데이터 구조 및 타입
- [x] CRUD 함수 정의
- [x] 오탈자 및 문법

